### PR TITLE
Close, minimize, fullscreen buttons fix

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -71,16 +71,13 @@ tab.tabbrowser-tab *{
 }
 
 #nav-bar-customization-target,
-#PanelUI-button * {
+#PanelUI-button,
+#titlebar * {
 	z-index: 1;
 }
 
 #alltabs-button {
 	display: none;
-}
-
-#titlebar {
-	z-index: 1;
 }
 
 /*------------------------------------------------*/

--- a/userChrome.css
+++ b/userChrome.css
@@ -70,6 +70,19 @@ tab.tabbrowser-tab *{
     transition: opacity 0.3s ease !important;
 }
 
+#nav-bar-customization-target,
+#PanelUI-button * {
+	z-index: 1;
+}
+
+#alltabs-button {
+	display: none;
+}
+
+#titlebar {
+	z-index: 1;
+}
+
 /*------------------------------------------------*/
 /* Remove line between website content and top bar */
 


### PR DESCRIPTION
This commit fixes the issue in Firefox with the title bar buttons (Close, minimize, fullscreen) not showing. This also disables the `#alltabs-button` because it's positioned behind the title bar buttons.